### PR TITLE
Allow specification of groups for clamav user

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,7 @@ class clamav (
       home    => $home,
       shell   => $shell,
       group   => $group,
+      groups  => $groups,
       before  => Package['clamav'],
       require => Anchor['clamav::begin'],
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,7 @@ class clamav (
   $home              = $clamav::params::home,
   $shell             = $clamav::params::shell,
   $group             = $clamav::params::group,
+  $groups            = $clamav::params::groups,
 
   $clamd_package     = $clamav::params::clamd_package,
   $clamd_config      = $clamav::params::clamd_config,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,7 @@ class clamav::params {
     $home              = '/var/lib/clamav'
     $shell             = '/sbin/nologin'
     $group             = 'clam'
+    $groups            = undef
 
     #### clamd vars ####
     $clamd_package     = 'clamd'

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -10,11 +10,13 @@ class clamav::user (
   $home    = $clamav::params::home,
   $shell   = $clamav::params::shell,
   $group   = $clamav::params::group,
+  $groups  = $clamav::params::groups,
 ) inherits clamav::params {
 
   validate_string($comment)
   validate_absolute_path($home)
   validate_absolute_path($shell)
+  validate_array($groups)
 
   if $group {
     group { 'clamav':
@@ -32,6 +34,7 @@ class clamav::user (
       comment => $comment,
       uid     => $uid,
       gid     => $gid,
+      groups  => $groups,
       home    => $home,
       shell   => $shell,
       system  => true,


### PR DESCRIPTION
In some setups its required that the clamav user is member of other
groups (e.g. amavis when clamav is integrated into the amavis virus
scanners). This patch adds a new parameter groups which allows to
pass those groups.
