### PR TITLE
Added 'PrivateMirror' parameter

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -161,6 +161,7 @@ class clamav::params {
       # Check for new database 24 times a day
       'Checks'                   => '24',
       'DatabaseMirror'           => ['db.local.clamav.net', 'database.clamav.net'],
+      'PrivateMirror'            => ['mirror1.mynetwork.com', 'mirror2.mynetwork.com'],
     }
   } else {
     fail("The ${module_name} module is not supported on a ${::osfamily} based system with version ${::operatingsystemrelease}.")

--- a/templates/freshclam.conf.RedHat.erb
+++ b/templates/freshclam.conf.RedHat.erb
@@ -128,6 +128,7 @@ DatabaseOwner <%= @freshclam_options.delete('DatabaseOwner') || 'clam' %>
 # Default: disabled
 #PrivateMirror mirror1.mynetwork.com
 #PrivateMirror mirror2.mynetwork.com
+<%= %Q(PrivateMirror #{@freshclam_options.delete('PrivateMirror')}\n) if @freshclam_options.key?('PrivateMirror') -%>
 
 # Number of database checks per day.
 # Default: 12 (every two hours)


### PR DESCRIPTION
Added 'PrivateMirror' configuration to allow freshclam to download Virus Database files from an internal (private) mirror.
