### PR TITLE
Added the ability to or not to have the clam and freshclam daemons running

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,10 @@ include clamav
 
 ```puppet
 class { 'clamav':
-  manage_clamd     => true,
-  manage_freshclam => true,
+  manage_clamd             => true,
+  manage_freshclam         => true,
+  clamd_service_ensure     => 'running',
+  freshclam_service_ensure => 'stopped',
 }
 ```
 

--- a/manifests/clamd.pp
+++ b/manifests/clamd.pp
@@ -25,7 +25,7 @@ class clamav::clamd (
   }
 
   service { 'clamd':
-    ensure     => running,
+    ensure     => $clamav::clamd_service_ensure,
     name       => $clamd_service,
     enable     => true,
     hasrestart => true,

--- a/manifests/clamd.pp
+++ b/manifests/clamd.pp
@@ -25,7 +25,7 @@ class clamav::clamd (
   }
 
   service { 'clamd':
-    ensure     => $clamav::clamd_service_ensure,
+    ensure     => $clamd_service_ensure,
     name       => $clamd_service,
     enable     => true,
     hasrestart => true,

--- a/manifests/freshclam.pp
+++ b/manifests/freshclam.pp
@@ -31,7 +31,7 @@ class clamav::freshclam (
   # NOTE: RedHat comes with /etc/cron.daily/freshclam instead of a service
   if $freshclam_service {
     service { 'freshclam':
-      ensure     => running,
+      ensure     => $clamd::freshclam_service_ensure,
       name       => $freshclam_service,
       enable     => true,
       hasrestart => true,

--- a/manifests/freshclam.pp
+++ b/manifests/freshclam.pp
@@ -31,7 +31,7 @@ class clamav::freshclam (
   # NOTE: RedHat comes with /etc/cron.daily/freshclam instead of a service
   if $freshclam_service {
     service { 'freshclam':
-      ensure     => $clamd::freshclam_service_ensure,
+      ensure     => $freshclam_service_ensure,
       name       => $freshclam_service,
       enable     => true,
       hasrestart => true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,31 +7,36 @@
 #
 
 class clamav (
-  $manage_user       = $clamav::params::manage_user,
-  $manage_repo       = $clamav::params::manage_repo,
-  $manage_clamd      = $clamav::params::manage_clamd,
-  $manage_freshclam  = $clamav::params::manage_freshclam,
-  $clamav_package    = $clamav::params::clamav_package,
+  $manage_user              = $clamav::params::manage_user,
+  $manage_repo              = $clamav::params::manage_repo,
+  $manage_clamd             = $clamav::params::manage_clamd,
+  $manage_freshclam         = $clamav::params::manage_freshclam,
+  $clamav_package           = $clamav::params::clamav_package,
 
-  $user              = $clamav::params::user,
-  $comment           = $clamav::params::comment,
-  $uid               = $clamav::params::uid,
-  $gid               = $clamav::params::gid,
-  $home              = $clamav::params::home,
-  $shell             = $clamav::params::shell,
-  $group             = $clamav::params::group,
-  $groups            = $clamav::params::groups,
+  $user                     = $clamav::params::user,
+  $comment                  = $clamav::params::comment,
+  $uid                      = $clamav::params::uid,
+  $gid                      = $clamav::params::gid,
+  $home                     = $clamav::params::home,
+  $shell                    = $clamav::params::shell,
+  $group                    = $clamav::params::group,
+  $groups                   = $clamav::params::groups,
 
-  $clamd_package     = $clamav::params::clamd_package,
-  $clamd_config      = $clamav::params::clamd_config,
-  $clamd_service     = $clamav::params::clamd_service,
-  $clamd_options     = $clamav::params::clamd_options,
+  $clamd_package            = $clamav::params::clamd_package,
+  $clamd_config             = $clamav::params::clamd_config,
+  $clamd_service            = $clamav::params::clamd_service,
+  $clamd_service_ensure     = $clamav::params::clamd_service_ensure,
+  $clamd_options            = $clamav::params::clamd_options,
 
-  $freshclam_package = $clamav::params::freshclam_package,
-  $freshclam_config  = $clamav::params::freshclam_config,
-  $freshclam_service = $clamav::params::freshclam_service,
-  $freshclam_options = $clamav::params::freshclam_options,
+  $freshclam_package        = $clamav::params::freshclam_package,
+  $freshclam_config         = $clamav::params::freshclam_config,
+  $freshclam_service        = $clamav::params::freshclam_service,
+  $freshclam_service_ensure = $clamav::params::freshclam_service_ensure,
+  $freshclam_options        = $clamav::params::freshclam_options,
 ) inherits clamav::params {
+
+  # Input validation
+  $valid_service_statuses = [ 'stopped', 'false', 'running', 'true', ]
 
   validate_bool($manage_user)
   validate_bool($manage_repo)
@@ -48,11 +53,13 @@ class clamav (
   validate_string($clamd_package)
   validate_absolute_path($clamd_config)
   validate_string($clamd_service)
+  validate_re($clamd_service_ensure, $valid_service_statuses)
   validate_hash($clamd_options)
   $_clamd_options = merge($clamav::params::clamd_default_options, $clamd_options)
 
   # freshclam
   validate_absolute_path($freshclam_config)
+  validate_re($freshclam_service_ensure, $valid_service_statuses)
   validate_hash($freshclam_options)
   $_freshclam_options = merge($clamav::params::freshclam_default_options, $freshclam_options)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,10 +7,11 @@
 class clamav::params {
 
   #### init vars ####
-  $manage_user      = false
-  $manage_clamd     = false
-  $manage_freshclam = false
-
+  $manage_user              = false
+  $manage_clamd             = false
+  $manage_freshclam         = false
+  $freshclam_service_ensure = 'running'
+  $clamd_service_ensure     = 'running'
 
   if ($::osfamily == 'RedHat') and (versioncmp($::operatingsystemrelease, '6.0') >= 0) {
     #### init vars ####


### PR DESCRIPTION
Added running/stopped values to params.pp, freshclam.pp, clamd.pp, init.pp so that the service can be configured to run or not.  Also added an example (probably not a real world one) to the README.
