### PR TITLE
Move the freshclam ordering from service to package

### DIFF
--- a/manifests/freshclam.pp
+++ b/manifests/freshclam.pp
@@ -37,8 +37,12 @@ class clamav::freshclam (
       enable     => true,
       hasrestart => true,
       hasstatus  => true,
-      subscribe  => [Package['freshclam'], File['freshclam.conf']],
+      subscribe  => File['freshclam.conf'],
     }
+  }
+
+  if $freshclam_package and $freshclam_service {
+    Package['freshclam'] ~> Service['freshclam']
   }
 
 }


### PR DESCRIPTION
In our infrastructure, to standardize between redhat and debian, we actually declare an init file for freshclam like so:

```
  case $::osfamily {
    RedHat : {
      file { '/etc/init.d/clamav-freshclam' :
        ensure => present,
        source => 'puppet:///modules/profile/clamav/freshclam-redhat-init',
        owner  => 'root',
        group  => 'root',
        mode   => '0755',
      }
      file { '/etc/cron.daily/freshclam' :
        ensure => absent,
      }
    }
  }
```

So we then declare our clamav the same way for Redhat and Debian:

```
  class { '::clamav' :
    [...]
    manage_freshclam  => true,
    freshclam_service => 'clamav-freshclam',
  }
```

but the manifest actually does not compile because of the `susbscribe` to the non-existent `Package['freshclam']`.

This is the fix I thought about.

I guess this would be bad in the case where `$freshclam_package = 'something'` and `$freshclam_service = undef`, but is it a real case?
