### PR TITLE
freshclam fix for RHEL7

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,8 @@ class clamav (
   $freshclam_service_ensure = $clamav::params::freshclam_service_ensure,
   $freshclam_service_enable = $clamav::params::freshclam_service_enable,
   $freshclam_options        = $clamav::params::freshclam_options,
+  $freshclam_sysconfig      = $clamav::params::freshclam_sysconfig,
+  $freshclam_delay          = $clamav::params::freshclam_delay,
 ) inherits clamav::params {
 
   # Input validation
@@ -68,7 +70,12 @@ class clamav (
   validate_bool($freshclam_service_enable)
   validate_hash($freshclam_options)
   $_freshclam_options = merge($clamav::params::freshclam_default_options, $freshclam_options)
-
+  if $freshclam_sysconfig {
+    validate_absolute_path($freshclam_sysconfig)
+  }
+  if $freshclam_delay {
+    validate_string($freshclam_delay)
+  }
 
   if $manage_repo { require '::epel' }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,9 +17,9 @@ class clamav::params {
 
   if ($::osfamily == 'RedHat') and (versioncmp($::operatingsystemrelease, '6.0') >= 0) {
     #### init vars ####
-    $manage_repo       = true
-    $clamav_package    = 'clamav'
-    $clamav_version    = 'installed'
+    $manage_repo    = true
+    $clamav_package = 'clamav'
+    $clamav_version = 'installed'
 
     if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
       #### user vars ####
@@ -53,6 +53,8 @@ class clamav::params {
         'LogSyslog'      => 'yes',
         'DatabaseMirror' => 'database.clamav.net',
       }
+      $freshclam_sysconfig = '/etc/sysconfig/freshclam'
+      $freshclam_delay     = undef
     } else {
       #### user vars ####
       $user              = 'clam'
@@ -104,6 +106,8 @@ class clamav::params {
         'DatabaseOwner'     => 'clam',
         'DatabaseMirror'    => ['db.us.clamav.net', 'db.local.clamav.net'],
       }
+      $freshclam_sysconfig = undef
+      $freshclam_delay     = undef
     }
   } elsif ($::osfamily == 'Debian') and (
     (($::operatingsystem == 'Debian') and (versioncmp($::operatingsystemrelease, '7.0') >= 0)) or
@@ -231,6 +235,8 @@ class clamav::params {
       'Checks'                   => '24',
       'DatabaseMirror'           => ['db.local.clamav.net', 'database.clamav.net'],
     }
+    $freshclam_sysconfig = undef
+    $freshclam_delay     = undef
   } else {
     fail("The ${module_name} module is not supported on a ${::osfamily} based system with version ${::operatingsystemrelease}.")
   }

--- a/spec/classes/clamav_spec.rb
+++ b/spec/classes/clamav_spec.rb
@@ -70,8 +70,10 @@ describe 'clamav', :type => :class do
           if facts[:osfamily] == 'RedHat'
             if facts[:operatingsystemmajrelease].to_i == 6
               it { is_expected.not_to contain_package('freshclam') }
+              it { is_expected.not_to contain_file('freshclam_sysconfig') }
             elsif facts[:operatingsystemmajrelease].to_i == 7
               it { is_expected.to contain_package('freshclam') }
+              it { is_expected.to contain_file('freshclam_sysconfig') }
             end
             it { is_expected.to contain_file('freshclam.conf') }
             it { is_expected.not_to contain_service('freshclam') }
@@ -79,6 +81,7 @@ describe 'clamav', :type => :class do
             it { is_expected.to contain_package('freshclam') }
             it { is_expected.to contain_file('freshclam.conf') }
             it { is_expected.to contain_service('freshclam') }
+            it { is_expected.not_to contain_file('freshclam_sysconfig') }
           end
         end
       end

--- a/templates/sysconfig/freshclam.erb
+++ b/templates/sysconfig/freshclam.erb
@@ -1,0 +1,3 @@
+<%= ERB.new(File.read(File.expand_path("_header.erb",File.dirname(File.dirname(file))))).result(binding) -%>
+
+FRESHCLAM_DELAY=<%= @freshclam_delay %>


### PR DESCRIPTION
Added a sysconfig file for freshclam in RHEL7.  RHEL7 comes by default with an option in `/etc/sysconfig/freshclam` which disables freshclam.  So, in order to make freshclam work, I needed to start managing that file in this module for RHEL7.
