### PR TITLE
strict variables requires all variables initialised

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ matrix:
   - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
   - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="no"
+    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
 notifications:
   email: false

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class clamav::params {
     $manage_repo    = true
     $clamav_package = 'clamav'
     $clamav_version = 'installed'
+    $freshclam_service = undef
 
     if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
       #### user vars ####
@@ -97,6 +98,8 @@ class clamav::params {
       }
 
       #### freshclam vars ####
+      $freshclam_package = undef
+      $freshclam_version = undef
       $freshclam_config  = '/etc/freshclam.conf'
       $freshclam_options = {}
       $freshclam_default_options = {


### PR DESCRIPTION
if puppet 4 with strict variables option active is used, all variables need to be initialized prior to using. So if the node is RedHat 6 freshclam_package, freshclam_version and freshclam_service need to be initialized otherwise a compilation error is thrown:

`Unknown variable: 'clamav::params::freshclam_package'. at /modules/clamav/manifests/init.pp:34:3`
