### PR TITLE
add FreeBSD support

### DIFF
--- a/manifests/clamav_milter.pp
+++ b/manifests/clamav_milter.pp
@@ -21,7 +21,7 @@ class clamav::clamav_milter {
     path    => $clamav::clamav_milter_config,
     mode    => '0644',
     owner   => 'root',
-    group   => 'root',
+    group   => $clamav::root_group,
     content => template("${module_name}/clamav.conf.erb"),
   }
 

--- a/manifests/clamd.pp
+++ b/manifests/clamd.pp
@@ -6,10 +6,21 @@ class clamav::clamd {
 
   $config_options = $clamav::_clamd_options
 
-  package { 'clamd':
-    ensure => $clamav::clamd_version,
-    name   => $clamav::clamd_package,
-    before => File['clamd.conf'],
+  # NOTE: In FreeBSD this is part of the base clamav_package
+  if $clamav::clamd_package {
+    package { 'clamd':
+      ensure => $clamav::clamd_version,
+      name   => $clamav::clamd_package,
+      before => File['clamd.conf'],
+    }
+    $service_subscribe = [
+      File['clamd.conf'],
+      Package['clamd'],
+    ]
+  } else {
+    $service_subscribe = [
+      File['clamd.conf'],
+    ]
   }
 
   file { 'clamd.conf':
@@ -17,7 +28,7 @@ class clamav::clamd {
     path    => $clamav::clamd_config,
     mode    => '0644',
     owner   => 'root',
-    group   => 'root',
+    group   => $clamav::root_group,
     content => template("${module_name}/clamav.conf.erb"),
   }
 
@@ -27,6 +38,6 @@ class clamav::clamd {
     enable     => $clamav::clamd_service_enable,
     hasrestart => true,
     hasstatus  => true,
-    subscribe  => [Package['clamd'], File['clamd.conf']],
+    subscribe  => $service_subscribe,
   }
 }

--- a/manifests/freshclam.pp
+++ b/manifests/freshclam.pp
@@ -7,7 +7,7 @@ class clamav::freshclam {
   $config_options = $clamav::_freshclam_options
   $freshclam_delay = $clamav::freshclam_delay
 
-  # NOTE: In RedHat this is part of the base clamav_package
+  # NOTE: In RedHat and FreeBSD this is part of the base clamav_package
   # NOTE: In Debian this is a dependency of the base clamav_package
   if $clamav::freshclam_package {
     package { 'freshclam':
@@ -22,7 +22,7 @@ class clamav::freshclam {
     path    => $clamav::freshclam_config,
     mode    => '0644',
     owner   => 'root',
-    group   => 'root',
+    group   => $clamav::root_group,
     content => template("${module_name}/clamav.conf.erb"),
   }
 
@@ -32,7 +32,7 @@ class clamav::freshclam {
       path    => $clamav::freshclam_sysconfig,
       mode    => '0644',
       owner   => 'root',
-      group   => 'root',
+      group   => $clamav::root_group,
       content => template("${module_name}/sysconfig/freshclam.erb"),
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,7 @@ class clamav (
   Stdlib::Absolutepath $shell   = $clamav::params::shell,
   $group                        = $clamav::params::group,
   $groups                       = $clamav::params::groups,
+  $root_group                   = $clamav::params::root_group,
 
   String $clamd_package         = $clamav::params::clamd_package,
   String $clamd_version         = $clamav::params::clamd_version,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,7 @@ class clamav::params {
     $manage_repo    = true
     $clamav_package = 'clamav'
     $clamav_version = 'installed'
+    $root_group = 'root'
 
     if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
       # ### user vars ####
@@ -135,6 +136,7 @@ class clamav::params {
     $manage_repo       = false
     $clamav_package    = 'clamav'
     $clamav_version    = 'installed'
+    $root_group        = 'root'
 
     # ### user vars ####
     $user              = 'clamav'
@@ -174,6 +176,59 @@ class clamav::params {
     $clamd_default_databasedirectory  = '/var/lib/clamav'
     $clamd_default_localsocket        = '/var/run/clamav/clamd.ctl'
     $clamd_default_logfile            = '/var/log/clamav/clamav.log'
+    $clamd_default_logrotate          = true
+    $clamd_default_logsyslog          = false
+    $clamd_default_pidfile            = '/var/run/clamav/clamd.pid'
+    $clamd_default_temporarydirectory = '/tmp'
+    $freshclam_default_databaseowner  = $user
+    $freshclam_default_pidfile        = '/var/run/clamav/freshclam.pid'
+    $freshclam_default_updatelogfile  = '/var/log/clamav/freshclam.log'
+
+  } elsif ($::osfamily == 'FreeBSD') {
+    #### init vars ####
+    $manage_repo       = false
+    $clamav_package    = 'clamav'
+    $clamav_version    = 'installed'
+    $root_group        = 'wheel'
+
+    #### user vars ####
+    $user              = 'clamav'
+    $comment           = undef
+    $uid               = 106
+    $gid               = 106
+    $home              = '/var/db/clamav'
+    $shell             = '/usr/sbin/nologin'
+    $group             = 'clamav'
+    $groups            = undef
+
+    #### clamd vars ####
+    $clamd_package     = undef
+    $clamd_version     = undef
+    $clamd_config      = '/usr/local/etc/clamd.conf'
+    $clamd_service     = 'clamav-clamd'
+    $clamd_options     = {}
+
+    #### freshclam vars ####
+    $freshclam_package = undef
+    $freshclam_version = undef
+    $freshclam_config  = '/usr/local/etc/freshclam.conf'
+    $freshclam_service = 'clamav-freshclam'
+    $freshclam_options = {}
+    $freshclam_sysconfig = undef
+    $freshclam_delay     = undef
+
+    #### clamav_milter vars ####
+    $clamav_milter_package     = undef
+    $clamav_milter_version     = undef
+    $clamav_milter_config      = undef
+    $clamav_milter_service     = undef
+    $clamav_milter_options     = undef
+    $clamav_milter_default_options = undef
+
+    #### Default values OS specific ####
+    $clamd_default_databasedirectory  = '/var/db/clamav'
+    $clamd_default_localsocket        = '/var/run/clamav/clamd.sock'
+    $clamd_default_logfile            = '/var/log/clamav/clamd.log'
     $clamd_default_logrotate          = true
     $clamd_default_logsyslog          = false
     $clamd_default_pidfile            = '/var/run/clamav/clamd.pid'

--- a/metadata.json
+++ b/metadata.json
@@ -52,6 +52,9 @@
         "14.04",
         "16.04"
       ]
+    },
+    {
+      "operatingsystem": "FreeBSD"
     }
   ],
   "requirements": [


### PR DESCRIPTION
* Add support for the FreeBSD operating system
* Make the "root" group configurable (it's "root" on Linux, "wheel" on FreeBSD)
* Tested on Puppet 5.x, change `metadata.json` accordingly