### PR TITLE
Hardcode clamav depenencies

### DIFF
--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -1,0 +1,14 @@
+class clamav::dependencies {
+  package {'clamav-filesystem':
+    ensure => $clamav::clamav_version,
+    name   => 'clamav-filesystem',
+  }
+  package {'clamav-data':
+    ensure => $clamav::clamav_version,
+    name   => 'clamav-data',
+  }
+  package {'clamav-lib':
+    ensure => $clamav::clamav_version,
+    name   => 'clamav-lib',
+  }
+}

--- a/manifests/freshclam.pp
+++ b/manifests/freshclam.pp
@@ -3,6 +3,7 @@
 #
 
 class clamav::freshclam {
+  require ::clamav::dependencies
 
   $config_options = $clamav::_freshclam_options
   $freshclam_delay = $clamav::freshclam_delay

--- a/manifests/freshclam.pp
+++ b/manifests/freshclam.pp
@@ -3,7 +3,6 @@
 #
 
 class clamav::freshclam {
-  require ::clamav::dependencies
 
   $config_options = $clamav::_freshclam_options
   $freshclam_delay = $clamav::freshclam_delay

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,6 +3,7 @@
 #
 
 class clamav::install {
+  require ::clamav::dependencies
 
   package { 'clamav':
     ensure => $clamav::clamav_version,


### PR DESCRIPTION
There is an issue with the clamav rpm package **0.99** in EPEL where the clamav-data dependency isn't hard coded. 
This means when puppet installs clamav v0.99 if it's using a repo with the new clamav v0.100 there will be mismatches between versions.

These changes add a dependencies class which install file system > data > lib using the param clamav_version so this issue isn't encountered.