### PR TITLE
Removed Default Option AllowSupplementaryGroups

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -66,7 +66,6 @@ class clamav::params {
       $clamav_milter_options     = {}
       $clamav_milter_default_options = {
         'User'                     => 'clamilt',
-        'AllowSupplementaryGroups' => 'yes',
         'MilterSocket'             => 'inet:8890@localhost',
         'ClamdSocket'              => 'tcp:127.0.0.1',
         'LogSyslog'                => 'yes',
@@ -183,7 +182,6 @@ class clamav::params {
   $clamd_default_options = {
     'AlgorithmicDetection'           => true,
     'AllowAllMatchScan'              => true,
-    'AllowSupplementaryGroups'       => true,
     'ArchiveBlockEncrypted'          => false,
     'Bytecode'                       => true,
     'BytecodeSecurity'               => 'TrustSigned',
@@ -252,7 +250,6 @@ class clamav::params {
   }
 
   $freshclam_default_options = {
-    'AllowSupplementaryGroups' => false,
     'Bytecode'                 => true,
     'Checks'                   => '24',
     'CompressLocalDatabase'    => 'no',


### PR DESCRIPTION
With ClamAV 0.100.0 this option is deprecated. 
https://blog.clamav.net/2018/04/clamav-01000-has-been-released.html