### PR TITLE
Removing clamd default options for forwards compatibility with 0.101

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -180,9 +180,7 @@ class clamav::params {
   }
 
   $clamd_default_options = {
-    'AlgorithmicDetection'           => true,
     'AllowAllMatchScan'              => true,
-    'ArchiveBlockEncrypted'          => false,
     'Bytecode'                       => true,
     'BytecodeSecurity'               => 'TrustSigned',
     'BytecodeTimeout'                => '60000',
@@ -190,7 +188,6 @@ class clamav::params {
     'CrossFilesystems'               => true,
     'DatabaseDirectory'              => $clamd_default_databasedirectory,
     'Debug'                          => false,
-    'DetectBrokenExecutables'        => false,
     'DetectPUA'                      => false,
     'DisableCertCheck'               => false,
     'ExitOnOOM'                      => false,
@@ -224,10 +221,7 @@ class clamav::params {
     'MaxScriptNormalize'             => '5M',
     'MaxThreads'                     => '12',
     'MaxZipTypeRcg'                  => '1M',
-    'OLE2BlockMacros'                => false,
     'OfficialDatabaseOnly'           => false,
-    'PhishingAlwaysBlockCloak'       => false,
-    'PhishingAlwaysBlockSSLMismatch' => false,
     'PhishingScanURLs'               => true,
     'PhishingSignatures'             => true,
     'PidFile'                        => $clamd_default_pidfile,


### PR DESCRIPTION
Fixes #62. Also removed other default options that have been renamed in `0.101` as the default values all correspond with the clamd defaults.