### PR TITLE
Upgrade stdlib maximum version and remove abandonware dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,8 +10,7 @@
   "tags": ["clam", "clamav", "clamscan", "clamdscan", "clamd", "freshclam", "virus", "antivirus"],
   "description": "Puppet Module to install/configure clamd and freshclam",
   "dependencies": [
-    {"name": "puppetlabs/stdlib", "version_requirement": ">= 4.1.0 < 5.0.0"},
-    {"name": "stahnma/epel", "version_requirement": ">= 0.0.6 < 2.0.0"}
+    {"name": "puppetlabs/stdlib", "version_requirement": ">= 4.1.0 < 7.0.0"}
   ],
   "operatingsystem_support": [
     {
@@ -28,7 +27,7 @@
     },
     {
       "operatingsystem": "Debian",
-      "operatingsystemrelease": ["8", "9"]
+      "operatingsystemrelease": ["8", "9", "10"]
     },
     {
       "operatingsystem": "Ubuntu",
@@ -38,7 +37,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0 < 6.0.0"
     }
   ]
 }


### PR DESCRIPTION
Upgrade stdlib maximum version to 7
State compatibility with debian 10
Remove dependency on abandoned 'epel' module, which seems to be some redhat thing, is not required for debian, and is an deprecated module with old dependencies