### PR TITLE
Remove deprecated setting AllowSupplementaryGroups

### DIFF
--- a/manifests/freshclam.pp
+++ b/manifests/freshclam.pp
@@ -26,6 +26,17 @@ class clamav::freshclam {
     content => template("${module_name}/clamav.conf.erb"),
   }
 
+  # NOTE: RedHat installations of clamav < 0.102 come with this flag which has been
+  # deprecated fro some time. When uprading to 0.102 or newer the setting perists,
+  # generating noise with cron jobs
+  file_line { 'Remove AllowSupplementaryGroups':
+    ensure            => absent,
+    path              => '/etc/freshclam.conf',
+    match             => '^AllowSupplementaryGroups ',
+    match_for_absence => true,
+    require           => File['freshclam.conf'],
+  }
+
   if $clamav::freshclam_sysconfig {
     file { 'freshclam_sysconfig':
       ensure  => file,


### PR DESCRIPTION
RedHat installations of clamav with versions < 0.102 come with the deprecated flag ```AllowSupplementaryGroups``` set in ```/etc/freshclam.conf```. After upgrading with the puppet module the setting is retained and generates noise in cron emails:

```
WARNING: Ignoring deprecated option AllowSupplementaryGroups at /etc/freshclam.conf:4
```

This change removes the configuration key ```AllowSupplementaryGroups``` if it's present in ```/etc/freshclam.conf```