### PR TITLE
PR for issue #69 - compatibility with RHEL/Centos 8.x

### DIFF
--- a/manifests/freshclam.pp
+++ b/manifests/freshclam.pp
@@ -44,7 +44,7 @@ class clamav::freshclam {
     $service_subscribe = File['freshclam.conf']
   }
 
-  # NOTE: RedHat comes with /etc/cron.daily/freshclam instead of a service
+  # NOTE: RedHat <8 comes with /etc/cron.daily/freshclam instead of a service
   if $clamav::freshclam_service {
     service { 'freshclam':
       ensure     => $clamav::freshclam_service_ensure,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,7 +23,6 @@ class clamav::params {
     $manage_repo    = true
     $clamav_package = 'clamav'
     $clamav_version = 'installed'
-    $freshclam_service = undef
 
     if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
       # ### user vars ####
@@ -57,6 +56,13 @@ class clamav::params {
       $freshclam_options = {}
       $freshclam_sysconfig = '/etc/sysconfig/freshclam'
       $freshclam_delay     = undef
+
+      # ### RHEL8/Centos8 actually do have a service
+      if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
+        $freshclam_service = 'clamav-freshclam'
+      } else {
+        $freshclam_service = undef
+      }
 
       # ### clamav_milter vars ####
       $clamav_milter_package     = 'clamav-milter-systemd'


### PR DESCRIPTION
This was actually easier than I anticipated.

The only change had to be made in the params, where I now set the service name to be a defined string (with the correct service name of course) while it stays undefined for RHEL/Centos 7.

Testing on my RHEL8 server, without the hack I used to circumvent the module's behaviour, showed no errors, and since the change is quite minimal I don't think it will break on RHEL7.

Michael Hinz