### PR TITLE
RHEL6 unbroken

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -75,8 +75,7 @@ class clamav::params {
         'MilterSocket'             => 'inet:8890@localhost',
         'ClamdSocket'              => 'tcp:127.0.0.1',
         'LogSyslog'                => 'yes',
-      }
-    } else {
+      } else {
       $freshclam_service = undef
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -76,6 +76,9 @@ class clamav::params {
         'ClamdSocket'              => 'tcp:127.0.0.1',
         'LogSyslog'                => 'yes',
       }
+    } else {
+      $freshclam_service = undef
+    }
 
     } else {
       # ### user vars ####

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -76,8 +76,8 @@ class clamav::params {
         'ClamdSocket'              => 'tcp:127.0.0.1',
         'LogSyslog'                => 'yes',
       } else {
-      $freshclam_service = undef
-    }
+        $freshclam_service = undef
+      }
 
     } else {
       # ### user vars ####


### PR DESCRIPTION
Sorry for breaking RHEL/Centos 6.

Looks a bit clumsy, but since you can't reassign variables in puppet that is how it has to be...

Totally untested since I don't have access to a RHEL6-box (anymore).