### PR TITLE
Fix for broken Redhat <7

### DIFF
--- a/manifests/freshclam.pp
+++ b/manifests/freshclam.pp
@@ -44,7 +44,7 @@ class clamav::freshclam {
     $service_subscribe = File['freshclam.conf']
   }
 
-  # NOTE: RedHat comes with /etc/cron.daily/freshclam instead of a service
+  # NOTE: RedHat <8 comes with /etc/cron.daily/freshclam instead of a service
   if $clamav::freshclam_service {
     service { 'freshclam':
       ensure     => $clamav::freshclam_service_ensure,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -109,6 +109,7 @@ class clamav::params {
       $freshclam_options = {}
       $freshclam_sysconfig = undef
       $freshclam_delay     = undef
+      $freshclam_service   = undef
 
       # ### clamav_milter vars ####
       $clamav_milter_package     = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,6 +57,8 @@ class clamav::params {
       $freshclam_sysconfig = '/etc/sysconfig/freshclam'
       $freshclam_delay     = undef
 
+      notify { 'freshclam service: ${freshclam_service} (should be undef)': }
+      
       # ### RHEL8/Centos8 actually do have a service
       if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
         $freshclam_service = 'clamav-freshclam'
@@ -156,7 +158,7 @@ class clamav::params {
     $freshclam_package = 'clamav-freshclam'
     $freshclam_version = 'installed'
     $freshclam_config  = '/etc/clamav/freshclam.conf'
-    $freshclam_service = 'clamav-freshclam'
+    $freshclam_service = 'clamav-freshclam'2
     $freshclam_options = {}
     $freshclam_sysconfig = undef
     $freshclam_delay     = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,8 +57,6 @@ class clamav::params {
       $freshclam_sysconfig = '/etc/sysconfig/freshclam'
       $freshclam_delay     = undef
 
-      notify { 'freshclam service: ${freshclam_service} (should be undef)': }
-
       # ### RHEL8/Centos8 actually do have a service
       if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
         $freshclam_service = 'clamav-freshclam'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,7 +23,6 @@ class clamav::params {
     $manage_repo    = true
     $clamav_package = 'clamav'
     $clamav_version = 'installed'
-    $freshclam_service = undef
 
     if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
       # ### user vars ####
@@ -61,6 +60,8 @@ class clamav::params {
       # ### RHEL8/Centos8 actually do have a service
       if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
         $freshclam_service = 'clamav-freshclam'
+      } else {
+        $freshclam_service = undef
       }
 
       # ### clamav_milter vars ####

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,7 +58,7 @@ class clamav::params {
       $freshclam_delay     = undef
 
       notify { 'freshclam service: ${freshclam_service} (should be undef)': }
-      
+
       # ### RHEL8/Centos8 actually do have a service
       if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
         $freshclam_service = 'clamav-freshclam'
@@ -158,7 +158,7 @@ class clamav::params {
     $freshclam_package = 'clamav-freshclam'
     $freshclam_version = 'installed'
     $freshclam_config  = '/etc/clamav/freshclam.conf'
-    $freshclam_service = 'clamav-freshclam'2
+    $freshclam_service = 'clamav-freshclam'
     $freshclam_options = {}
     $freshclam_sysconfig = undef
     $freshclam_delay     = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,6 +58,11 @@ class clamav::params {
       $freshclam_sysconfig = '/etc/sysconfig/freshclam'
       $freshclam_delay     = undef
 
+      # ### RHEL8/Centos8 actually do have a service
+      if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
+        $freshclam_service = 'clamav-freshclam'
+      }
+
       # ### clamav_milter vars ####
       $clamav_milter_package     = 'clamav-milter-systemd'
       $clamav_milter_version     = 'installed'


### PR DESCRIPTION
Reintroduce the $freshclam_service variable for Redhat 6.x and earlier.